### PR TITLE
Undefined parameter

### DIFF
--- a/backtrader/indicators/ols.py
+++ b/backtrader/indicators/ols.py
@@ -54,7 +54,7 @@ class OLS_Slope_InterceptN(PeriodN):
     def next(self):
         p0 = pd.Series(self.data0.get(size=self.p.period))
         p1 = pd.Series(self.data1.get(size=self.p.period))
-        p1 = sm.add_constant(p1, prepend=prepend_constant)
+        p1 = sm.add_constant(p1, prepend=self.p.prepend_constant)
         slope, intercept = sm.OLS(p0, p1).fit().params
 
         self.lines.slope[0] = slope


### PR DESCRIPTION
Add `self.p` to `prepend_constant` parameter, otherwise receive the error `NameError: name 'prepend_constant' is not defined`.

Could not get the `OLS_TransformationN` indicator to work without this.